### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI - Git Log HTML Report
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/sajjad-developer/git-log-html-report/security/code-scanning/1](https://github.com/sajjad-developer/git-log-html-report/security/code-scanning/1)

#### General Fix:
Add a `permissions` block to the workflow file to explicitly limit the privileges of the `GITHUB_TOKEN`. The permissions should be scoped to only what is necessary for the tasks performed in the workflow.

#### Detailed Fix:
- Add a `permissions` block at the workflow level to ensure all jobs within the workflow inherit the specified least privileges.
- Since the workflow primarily reads repository contents and uploads artifacts, set the `permissions` block to `contents: read` and `actions: write`.

#### Specific Changes:
- Add the following `permissions` block at the top level of the workflow:
  ```yaml
  permissions:
    contents: read
    actions: write
  ```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
