### PR TITLE
feat(postinstall): skip postinstall message in CI environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npx git-log-html-report
 
 ---
 
-Navigation Links for Your Convenience
+### 🔗 Quick Links
 
 - [📦 Usage](README.en.md#-usage)
 - [📋 Requirements](README.en.md#-requirements)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-log-html-report",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generate clean, themed, and printable HTML reports from Git logs with timestamps and commit metadata.",
   "type": "module",
   "bin": {

--- a/postinstall-message.js
+++ b/postinstall-message.js
@@ -1,16 +1,17 @@
 // postinstall-message.js
 import chalk from "chalk";
 
-// Detect if running in a CI environment (like Packagephobia's sandbox)
-// process.env.CI is a common environment variable set in many CI/CD systems.
-// process.env.NODE_ENV === 'test' is another common check.
-// Packagephobia might set its own specific env var, but CI is a good general one.
-if (process.env.CI || process.env.PACKAGEPHOBIA_TEST) {
-  // PACKAGEPHOBIA_TEST is hypothetical, but CI is often set
-  // console.log(chalk.gray("Skipping postinstall message in CI/automated environment."));
-  process.exit(0); // Exit successfully without printing the message
+// Check if the CI environment variable is set to a truthy value.
+// This is a common practice to detect automated environments like GitHub Actions,
+// Packagephobia, etc.
+if (process.env.CI) {
+  // If in a CI environment, exit silently.
+  // This prevents unnecessary output during automated installs and prevents
+  // Packagephobia from failing due to unexpected output or behavior.
+  process.exit(0);
 }
 
+// If not in a CI environment, print the welcome message as intended for local users.
 console.log(
   chalk.cyan("✨ Thank you for installing git-log-html-report!") +
     "\n\n" +

--- a/postinstall-message.js
+++ b/postinstall-message.js
@@ -1,10 +1,12 @@
 // postinstall-message.js
 import chalk from "chalk";
 
-// Use a custom environment variable for conditional logic.
-// This is more reliable as CI systems are less likely to override it.
-// Also keep process.env.CI check as a fallback for general CI detection.
-if (process.env.CI || process.env.GIT_LOG_HTML_REPORT_CI_TEST === "true") {
+// Only run the message if NOT in CI or automated test environment
+const isCI = process.env.CI === "true";
+const isCustomCITest = process.env.GIT_LOG_HTML_REPORT_CI_TEST === "true";
+
+if (isCI || isCustomCITest) {
+  // Exit silently in CI or test environment
   process.exit(0);
 }
 

--- a/postinstall-message.js
+++ b/postinstall-message.js
@@ -1,6 +1,16 @@
 // postinstall-message.js
 import chalk from "chalk";
 
+// Detect if running in a CI environment (like Packagephobia's sandbox)
+// process.env.CI is a common environment variable set in many CI/CD systems.
+// process.env.NODE_ENV === 'test' is another common check.
+// Packagephobia might set its own specific env var, but CI is a good general one.
+if (process.env.CI || process.env.PACKAGEPHOBIA_TEST) {
+  // PACKAGEPHOBIA_TEST is hypothetical, but CI is often set
+  // console.log(chalk.gray("Skipping postinstall message in CI/automated environment."));
+  process.exit(0); // Exit successfully without printing the message
+}
+
 console.log(
   chalk.cyan("✨ Thank you for installing git-log-html-report!") +
     "\n\n" +

--- a/postinstall-message.js
+++ b/postinstall-message.js
@@ -1,17 +1,13 @@
 // postinstall-message.js
 import chalk from "chalk";
 
-// Check if the CI environment variable is set to a truthy value.
-// This is a common practice to detect automated environments like GitHub Actions,
-// Packagephobia, etc.
-if (process.env.CI) {
-  // If in a CI environment, exit silently.
-  // This prevents unnecessary output during automated installs and prevents
-  // Packagephobia from failing due to unexpected output or behavior.
+// Use a custom environment variable for conditional logic.
+// This is more reliable as CI systems are less likely to override it.
+// Also keep process.env.CI check as a fallback for general CI detection.
+if (process.env.CI || process.env.GIT_LOG_HTML_REPORT_CI_TEST === "true") {
   process.exit(0);
 }
 
-// If not in a CI environment, print the welcome message as intended for local users.
 console.log(
   chalk.cyan("✨ Thank you for installing git-log-html-report!") +
     "\n\n" +

--- a/tests/postinstall-message.test.js
+++ b/tests/postinstall-message.test.js
@@ -8,18 +8,18 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const scriptPath = join(__dirname, "../postinstall-message.js");
 
 describe("postinstall-message.js", () => {
-  // Test 1: Verify output when NOT in an "automated test" environment
+  // Test 1: Verify output when NOT in an automated test environment
   it("should print the welcome message when not in automated test environment", () => {
-    // Pass environment variables to explicitly disable custom test flags
+    const env = {
+      ...process.env,
+      GIT_LOG_HTML_REPORT_CI_TEST: "false", // explicitly false
+    };
+
+    // IMPORTANT: Remove CI variable completely to simulate non-CI environment
+    delete env.CI;
+
     const output = execFileSync("node", [scriptPath], {
-      env: {
-        ...process.env,
-        // Make sure our custom test flag is NOT set for this test
-        GIT_LOG_HTML_REPORT_CI_TEST: "false",
-        // Also ensure common CI var is set to false if it's being checked.
-        // This is a belt-and-suspenders approach.
-        CI: "false",
-      },
+      env,
     }).toString();
 
     expect(output).toMatch(/Thank you for installing git-log-html-report/i);
@@ -27,15 +27,16 @@ describe("postinstall-message.js", () => {
     expect(output).toMatch(/Tip Me: https:\/\/eco-starfish-coder.com\/tip/);
   });
 
-  // Test 2: Verify no output when in an "automated test" environment
+  // Test 2: Verify no output when in an automated test environment
   it("should NOT print the welcome message when in automated test environment", () => {
-    // Pass environment variables to explicitly enable custom test flag
+    const env = {
+      ...process.env,
+      GIT_LOG_HTML_REPORT_CI_TEST: "true",
+      CI: "true",
+    };
+
     const output = execFileSync("node", [scriptPath], {
-      env: {
-        ...process.env,
-        GIT_LOG_HTML_REPORT_CI_TEST: "true", // Set our custom test flag to 'true'
-        CI: "true", // Also ensure common CI var is set to true for this test
-      },
+      env,
     }).toString();
 
     expect(output).toBe("");

--- a/tests/postinstall-message.test.js
+++ b/tests/postinstall-message.test.js
@@ -2,37 +2,43 @@
 import { execFileSync } from "child_process";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const scriptPath = join(__dirname, "../postinstall-message.js");
 
 describe("postinstall-message.js", () => {
-  let originalCIEnv; // Declare a variable to store the original CI environment state
-
-  beforeEach(() => {
-    // Store original CI env var state before each test
-    originalCIEnv = process.env.CI;
-    // Temporarily set CI to 'false' for the test runner's process
-    process.env.CI = "false";
+  // Use vi.stubGlobal to mock the entire process object,
+  // specifically its env property, for the duration of this test suite.
+  // This ensures that when postinstall-message.js reads process.env.CI,
+  // it gets the mocked value.
+  vi.stubGlobal("process", {
+    env: {
+      ...process.env, // Keep existing environment variables
+      CI: "false", // Explicitly set CI to 'false' for the test environment
+    },
   });
 
-  afterEach(() => {
-    // Restore original CI env var state after each test
-    process.env.CI = originalCIEnv; // Restore the original value
-  });
-
-  it("should run without errors and print key lines", () => {
-    // Execute the postinstall-message.js script
-    // Pass the modified environment explicitly to the child process
-    // This ensures the child process (postinstall-message.js) sees CI: 'false'
-    const output = execFileSync("node", [scriptPath], {
-      env: { ...process.env, CI: "false" }, // Pass all current env vars, but explicitly set CI to 'false'
-    }).toString();
+  it("should run without errors and print key lines when not in CI", () => {
+    // Execute the postinstall-message.js script.
+    // It should now print its message because process.env.CI is mocked to 'false'.
+    const output = execFileSync("node", [scriptPath]).toString();
 
     // Assert that the output matches the expected messages
     expect(output).toMatch(/Thank you for installing git-log-html-report/i);
     expect(output).toMatch(/git-log-html-report/);
     expect(output).toMatch(/Tip Me: https:\/\/eco-starfish-coder.com\/tip/);
+  });
+
+  // Add a test to ensure it *does not* print when CI is true
+  it("should NOT print the welcome message when in CI", () => {
+    // Execute the postinstall-message.js script with CI explicitly set to 'true'.
+    // This tests the conditional logic within postinstall-message.js itself.
+    const output = execFileSync("node", [scriptPath], {
+      env: { ...process.env, CI: "true" },
+    }).toString();
+
+    // Assert that the output is empty
+    expect(output).toBe("");
   });
 });

--- a/tests/postinstall-message.test.js
+++ b/tests/postinstall-message.test.js
@@ -1,12 +1,27 @@
+// tests/postinstall-message.test.js
 import { execFileSync } from "child_process";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest"; // Import beforeEach and afterEach
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const scriptPath = join(__dirname, "../postinstall-message.js");
 
 describe("postinstall-message.js", () => {
+  let originalCIEnv;
+
+  beforeEach(() => {
+    // Store original CI env var state
+    originalCIEnv = process.env.CI;
+    // Temporarily set CI to 'false' for the test to ensure postinstall-message.js runs
+    process.env.CI = "false";
+  });
+
+  afterEach(() => {
+    // Restore original CI env var state after the test
+    process.env.CI = originalCIEnv;
+  });
+
   it("should run without errors and print key lines", () => {
     const output = execFileSync("node", [scriptPath]).toString();
 

--- a/tests/postinstall-message.test.js
+++ b/tests/postinstall-message.test.js
@@ -13,8 +13,7 @@ describe("postinstall-message.js", () => {
   beforeEach(() => {
     // Store original CI env var state before each test
     originalCIEnv = process.env.CI;
-    // Temporarily set CI to 'false' for the test to ensure postinstall-message.js runs
-    // This allows the test to always receive output from postinstall-message.js
+    // Temporarily set CI to 'false' for the test runner's process
     process.env.CI = "false";
   });
 
@@ -25,7 +24,11 @@ describe("postinstall-message.js", () => {
 
   it("should run without errors and print key lines", () => {
     // Execute the postinstall-message.js script
-    const output = execFileSync("node", [scriptPath]).toString();
+    // Pass the modified environment explicitly to the child process
+    // This ensures the child process (postinstall-message.js) sees CI: 'false'
+    const output = execFileSync("node", [scriptPath], {
+      env: { ...process.env, CI: "false" }, // Pass all current env vars, but explicitly set CI to 'false'
+    }).toString();
 
     // Assert that the output matches the expected messages
     expect(output).toMatch(/Thank you for installing git-log-html-report/i);

--- a/tests/postinstall-message.test.js
+++ b/tests/postinstall-message.test.js
@@ -2,29 +2,32 @@
 import { execFileSync } from "child_process";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest"; // Import beforeEach and afterEach
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const scriptPath = join(__dirname, "../postinstall-message.js");
 
 describe("postinstall-message.js", () => {
-  let originalCIEnv;
+  let originalCIEnv; // Declare a variable to store the original CI environment state
 
   beforeEach(() => {
-    // Store original CI env var state
+    // Store original CI env var state before each test
     originalCIEnv = process.env.CI;
     // Temporarily set CI to 'false' for the test to ensure postinstall-message.js runs
+    // This allows the test to always receive output from postinstall-message.js
     process.env.CI = "false";
   });
 
   afterEach(() => {
-    // Restore original CI env var state after the test
-    process.env.CI = originalCIEnv;
+    // Restore original CI env var state after each test
+    process.env.CI = originalCIEnv; // Restore the original value
   });
 
   it("should run without errors and print key lines", () => {
+    // Execute the postinstall-message.js script
     const output = execFileSync("node", [scriptPath]).toString();
 
+    // Assert that the output matches the expected messages
     expect(output).toMatch(/Thank you for installing git-log-html-report/i);
     expect(output).toMatch(/git-log-html-report/);
     expect(output).toMatch(/Tip Me: https:\/\/eco-starfish-coder.com\/tip/);

--- a/tests/postinstall-message.test.js
+++ b/tests/postinstall-message.test.js
@@ -2,43 +2,42 @@
 import { execFileSync } from "child_process";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const scriptPath = join(__dirname, "../postinstall-message.js");
 
 describe("postinstall-message.js", () => {
-  // Use vi.stubGlobal to mock the entire process object,
-  // specifically its env property, for the duration of this test suite.
-  // This ensures that when postinstall-message.js reads process.env.CI,
-  // it gets the mocked value.
-  vi.stubGlobal("process", {
-    env: {
-      ...process.env, // Keep existing environment variables
-      CI: "false", // Explicitly set CI to 'false' for the test environment
-    },
-  });
+  // Test 1: Verify output when NOT in an "automated test" environment
+  it("should print the welcome message when not in automated test environment", () => {
+    // Pass environment variables to explicitly disable custom test flags
+    const output = execFileSync("node", [scriptPath], {
+      env: {
+        ...process.env,
+        // Make sure our custom test flag is NOT set for this test
+        GIT_LOG_HTML_REPORT_CI_TEST: "false",
+        // Also ensure common CI var is set to false if it's being checked.
+        // This is a belt-and-suspenders approach.
+        CI: "false",
+      },
+    }).toString();
 
-  it("should run without errors and print key lines when not in CI", () => {
-    // Execute the postinstall-message.js script.
-    // It should now print its message because process.env.CI is mocked to 'false'.
-    const output = execFileSync("node", [scriptPath]).toString();
-
-    // Assert that the output matches the expected messages
     expect(output).toMatch(/Thank you for installing git-log-html-report/i);
     expect(output).toMatch(/git-log-html-report/);
     expect(output).toMatch(/Tip Me: https:\/\/eco-starfish-coder.com\/tip/);
   });
 
-  // Add a test to ensure it *does not* print when CI is true
-  it("should NOT print the welcome message when in CI", () => {
-    // Execute the postinstall-message.js script with CI explicitly set to 'true'.
-    // This tests the conditional logic within postinstall-message.js itself.
+  // Test 2: Verify no output when in an "automated test" environment
+  it("should NOT print the welcome message when in automated test environment", () => {
+    // Pass environment variables to explicitly enable custom test flag
     const output = execFileSync("node", [scriptPath], {
-      env: { ...process.env, CI: "true" },
+      env: {
+        ...process.env,
+        GIT_LOG_HTML_REPORT_CI_TEST: "true", // Set our custom test flag to 'true'
+        CI: "true", // Also ensure common CI var is set to true for this test
+      },
     }).toString();
 
-    // Assert that the output is empty
     expect(output).toBe("");
   });
 });


### PR DESCRIPTION
- Adds a check in `postinstall-message.js` to prevent the postinstall message from appearing in CI or automated environments, reducing unnecessary output during installation.
- Bumps the version from `1.0.0` to `1.0.1` in `package.json` to reflect this improvement.